### PR TITLE
Implement citizen budget-allocation backend APIs and paginated project list

### DIFF
--- a/website/app/api/citizen/budget-allocation/projects/route.ts
+++ b/website/app/api/citizen/budget-allocation/projects/route.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from "next/server";
+import { DBV2_SECTOR_CODES, type DashboardSectorCode } from "@/lib/constants/dashboard";
+import { supabaseServer } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type ScopeType = "city" | "barangay";
+
+type ProjectsErrorCode = "BAD_REQUEST" | "NOT_FOUND" | "INTERNAL_ERROR";
+
+type ProjectRow = {
+  id: string;
+  aip_ref_code: string;
+  program_project_description: string;
+  source_of_funds: string | null;
+  total: number | null;
+};
+
+function errorResponse(status: number, code: ProjectsErrorCode, message: string) {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function clampPageSize(value: number): number {
+  if (!Number.isFinite(value)) return 10;
+  return Math.min(50, Math.max(5, Math.floor(value)));
+}
+
+function parseParams(searchParams: URLSearchParams) {
+  const fiscalYear = Number(searchParams.get("fiscal_year"));
+  const scopeTypeRaw = searchParams.get("scope_type");
+  const scopeId = searchParams.get("scope_id")?.trim() ?? "";
+  const page = Number(searchParams.get("page") ?? "1");
+  const pageSize = clampPageSize(Number(searchParams.get("pageSize") ?? "10"));
+  const q = searchParams.get("q")?.trim() ?? "";
+  const countMode = searchParams.get("count") === "none" ? "none" : "exact";
+
+  const sectorCodeRaw = searchParams.get("sector_code")?.trim() ?? "";
+  const sectorCode = DBV2_SECTOR_CODES.includes(sectorCodeRaw as DashboardSectorCode)
+    ? (sectorCodeRaw as DashboardSectorCode)
+    : null;
+
+  if (!Number.isInteger(fiscalYear) || fiscalYear < 1900) return null;
+  if (scopeTypeRaw !== "city" && scopeTypeRaw !== "barangay") return null;
+  if (!UUID_PATTERN.test(scopeId)) return null;
+  if (!Number.isInteger(page) || page < 1) return null;
+  if (sectorCodeRaw && !sectorCode) return null;
+
+  return {
+    fiscalYear,
+    scopeType: scopeTypeRaw as ScopeType,
+    scopeId,
+    page,
+    pageSize,
+    q,
+    sectorCode,
+    countMode,
+  };
+}
+
+function escapeForIlike(input: string): string {
+  return input.replace(/[%_,]/g, (token) => `\\${token}`);
+}
+
+function buildProjectQuery(input: {
+  client: Awaited<ReturnType<typeof supabaseServer>>;
+  withCount: boolean;
+  fiscalYear: number;
+  scopeColumn: "city_id" | "barangay_id";
+  scopeId: string;
+  sectorCode: DashboardSectorCode | null;
+  q: string;
+}) {
+  let query = input.client
+    .from("projects")
+    .select(
+      "id,aip_ref_code,program_project_description,source_of_funds,total,aips!inner(id)",
+      input.withCount ? { count: "exact" } : undefined
+    )
+    .eq("aips.status", "published")
+    .eq("aips.fiscal_year", input.fiscalYear)
+    .eq(`aips.${input.scopeColumn}`, input.scopeId)
+    .in("sector_code", [...DBV2_SECTOR_CODES]);
+
+  if (input.sectorCode) {
+    query = query.eq("sector_code", input.sectorCode);
+  }
+
+  if (input.q) {
+    const escaped = escapeForIlike(input.q);
+    query = query.or(`aip_ref_code.ilike.%${escaped}%,program_project_description.ilike.%${escaped}%`);
+  }
+
+  return query;
+}
+
+export async function GET(request: Request) {
+  const parsed = parseParams(new URL(request.url).searchParams);
+  if (!parsed) {
+    return errorResponse(
+      400,
+      "BAD_REQUEST",
+      "Invalid or missing query params. Required: fiscal_year, scope_type (city|barangay), scope_id (UUID)."
+    );
+  }
+
+  const from = (parsed.page - 1) * parsed.pageSize;
+  const to = from + parsed.pageSize - 1;
+  const scopeColumn = parsed.scopeType === "city" ? "city_id" : "barangay_id";
+
+  try {
+    const client = await supabaseServer();
+
+    const { count: aipCount, error: aipError } = await client
+      .from("aips")
+      .select("id", { head: true, count: "exact" })
+      .eq("status", "published")
+      .eq("fiscal_year", parsed.fiscalYear)
+      .eq(scopeColumn, parsed.scopeId);
+
+    if (aipError) {
+      return errorResponse(500, "INTERNAL_ERROR", "Failed to validate published budget allocation scope.");
+    }
+
+    if (!aipCount || aipCount < 1) {
+      return errorResponse(
+        404,
+        "NOT_FOUND",
+        "No published budget allocation was found for the selected fiscal year and LGU scope."
+      );
+    }
+
+    const { data, error, count } = await buildProjectQuery({
+      client,
+      withCount: parsed.countMode === "exact",
+      fiscalYear: parsed.fiscalYear,
+      scopeColumn,
+      scopeId: parsed.scopeId,
+      sectorCode: parsed.sectorCode,
+      q: parsed.q,
+    })
+      .order("total", { ascending: false, nullsFirst: false })
+      .order("aip_ref_code", { ascending: true })
+      .range(from, to)
+      .returns<ProjectRow[]>();
+
+    if (error) {
+      return errorResponse(500, "INTERNAL_ERROR", "Failed to load project list.");
+    }
+
+    const items = (data ?? []).map((row) => ({
+      project_id: row.id,
+      aip_ref_code: row.aip_ref_code,
+      program_project_description: row.program_project_description,
+      source_of_funds: row.source_of_funds,
+      total: typeof row.total === "number" ? row.total : 0,
+    }));
+
+    const totalRows = parsed.countMode === "exact" ? count ?? 0 : -1;
+    const totalPages = totalRows >= 0 ? Math.max(1, Math.ceil(totalRows / parsed.pageSize)) : -1;
+
+    return NextResponse.json({
+      items,
+      page: parsed.page,
+      pageSize: parsed.pageSize,
+      totalRows,
+      totalPages,
+    });
+  } catch {
+    return errorResponse(500, "INTERNAL_ERROR", "Unexpected error while loading budget allocation projects.");
+  }
+}

--- a/website/app/api/citizen/budget-allocation/summary/route.ts
+++ b/website/app/api/citizen/budget-allocation/summary/route.ts
@@ -1,0 +1,169 @@
+import { NextResponse } from "next/server";
+import { DBV2_SECTOR_CODES, getSectorLabel, type DashboardSectorCode } from "@/lib/constants/dashboard";
+import { supabaseServer } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type ScopeType = "city" | "barangay";
+
+type SummaryErrorCode = "BAD_REQUEST" | "NOT_FOUND" | "INTERNAL_ERROR";
+
+function errorResponse(status: number, code: SummaryErrorCode, message: string) {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+function parseScope(searchParams: URLSearchParams): {
+  fiscalYear: number;
+  scopeType: ScopeType;
+  scopeId: string;
+} | null {
+  const fiscalYearRaw = searchParams.get("fiscal_year");
+  const scopeTypeRaw = searchParams.get("scope_type");
+  const scopeId = searchParams.get("scope_id")?.trim() ?? "";
+
+  const fiscalYear = Number(fiscalYearRaw);
+  if (!Number.isInteger(fiscalYear) || fiscalYear < 1900) return null;
+  if (scopeTypeRaw !== "city" && scopeTypeRaw !== "barangay") return null;
+  if (!UUID_PATTERN.test(scopeId)) return null;
+
+  return {
+    fiscalYear,
+    scopeType: scopeTypeRaw,
+    scopeId,
+  };
+}
+
+function toAmount(value: number | null): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export async function GET(request: Request) {
+  const parsed = parseScope(new URL(request.url).searchParams);
+  if (!parsed) {
+    return errorResponse(
+      400,
+      "BAD_REQUEST",
+      "Invalid or missing query params. Required: fiscal_year, scope_type (city|barangay), scope_id (UUID)."
+    );
+  }
+
+  const scopeColumn = parsed.scopeType === "city" ? "city_id" : "barangay_id";
+  const scopeTable = parsed.scopeType === "city" ? "cities" : "barangays";
+
+  try {
+    const client = await supabaseServer();
+
+    const [{ data: scopeRow, error: scopeError }, { data: publishedAips, error: aipsError }] = await Promise.all([
+      client.from(scopeTable).select("name").eq("id", parsed.scopeId).maybeSingle(),
+      client
+        .from("aips")
+        .select("id,fiscal_year")
+        .eq("status", "published")
+        .eq(scopeColumn, parsed.scopeId)
+        .lte("fiscal_year", parsed.fiscalYear)
+        .order("fiscal_year", { ascending: false })
+        .limit(5),
+    ]);
+
+    if (scopeError) {
+      return errorResponse(500, "INTERNAL_ERROR", "Failed to resolve scope details.");
+    }
+    if (aipsError) {
+      return errorResponse(500, "INTERNAL_ERROR", "Failed to load published budget allocation data.");
+    }
+
+    const selectedAip = (publishedAips ?? []).find((aip) => aip.fiscal_year === parsed.fiscalYear);
+    if (!selectedAip) {
+      return errorResponse(
+        404,
+        "NOT_FOUND",
+        "No published budget allocation was found for the selected fiscal year and LGU scope."
+      );
+    }
+
+    const trendAips = [...(publishedAips ?? [])].sort((a, b) => a.fiscal_year - b.fiscal_year);
+    const trendAipIds = trendAips.map((aip) => aip.id);
+    const yearByAipId = new Map(trendAips.map((aip) => [aip.id, aip.fiscal_year]));
+
+    const [{ data: selectedProjects, error: selectedProjectsError }, { data: trendProjects, error: trendProjectsError }] =
+      await Promise.all([
+        client
+          .from("projects")
+          .select("sector_code,total")
+          .eq("aip_id", selectedAip.id)
+          .in("sector_code", [...DBV2_SECTOR_CODES]),
+        client
+          .from("projects")
+          .select("aip_id,sector_code,total")
+          .in("aip_id", trendAipIds)
+          .in("sector_code", [...DBV2_SECTOR_CODES]),
+      ]);
+
+    if (selectedProjectsError || trendProjectsError) {
+      return errorResponse(500, "INTERNAL_ERROR", "Failed to load project budget totals.");
+    }
+
+    const totalsBySector = new Map<DashboardSectorCode, number>(DBV2_SECTOR_CODES.map((code) => [code, 0]));
+
+    (selectedProjects ?? []).forEach((project) => {
+      const code = project.sector_code as DashboardSectorCode;
+      totalsBySector.set(code, (totalsBySector.get(code) ?? 0) + toAmount(project.total));
+    });
+
+    const overallTotal = DBV2_SECTOR_CODES.reduce((sum, code) => sum + (totalsBySector.get(code) ?? 0), 0);
+
+    const bySector = DBV2_SECTOR_CODES.map((sectorCode) => {
+      const total = totalsBySector.get(sectorCode) ?? 0;
+      return {
+        sector_code: sectorCode,
+        sector_label: getSectorLabel(sectorCode),
+        total,
+        pct: overallTotal > 0 ? total / overallTotal : 0,
+      };
+    });
+
+    const years = trendAips.map((aip) => aip.fiscal_year);
+    const yearSectorTotals = new Map<number, Map<DashboardSectorCode, number>>();
+
+    years.forEach((year) => {
+      yearSectorTotals.set(year, new Map<DashboardSectorCode, number>(DBV2_SECTOR_CODES.map((code) => [code, 0])));
+    });
+
+    (trendProjects ?? []).forEach((project) => {
+      const year = yearByAipId.get(project.aip_id);
+      const code = project.sector_code as DashboardSectorCode;
+      if (typeof year !== "number" || !yearSectorTotals.has(year)) return;
+      const sectorMap = yearSectorTotals.get(year);
+      if (!sectorMap) return;
+      sectorMap.set(code, (sectorMap.get(code) ?? 0) + toAmount(project.total));
+    });
+
+    const series = DBV2_SECTOR_CODES.map((sectorCode) => ({
+      sector_code: sectorCode,
+      sector_label: getSectorLabel(sectorCode),
+      values: years.map((year) => yearSectorTotals.get(year)?.get(sectorCode) ?? 0),
+    }));
+
+    return NextResponse.json({
+      scope: {
+        fiscal_year: parsed.fiscalYear,
+        scope_type: parsed.scopeType,
+        scope_id: parsed.scopeId,
+        scope_name: scopeRow?.name ?? null,
+      },
+      totals: {
+        overall_total: overallTotal,
+        by_sector: bySector,
+      },
+      trend: {
+        years,
+        series,
+      },
+    });
+  } catch {
+    return errorResponse(500, "INTERNAL_ERROR", "Unexpected error while loading budget allocation summary.");
+  }
+}

--- a/website/features/citizen/budget-allocation/components/aip-details-section.tsx
+++ b/website/features/citizen/budget-allocation/components/aip-details-section.tsx
@@ -15,9 +15,13 @@ type AipDetailsSectionProps = {
   onTabChange: (key: BudgetCategoryKey) => void;
   onSearchChange: (value: string) => void;
   viewAllHref: string;
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
 };
 
-export default function AipDetailsSection({ vm, onTabChange, onSearchChange, viewAllHref }: AipDetailsSectionProps) {
+export default function AipDetailsSection({ vm, onTabChange, onSearchChange, viewAllHref, page, totalPages, onPageChange }: AipDetailsSectionProps) {
+  const hasPagination = totalPages > 0;
   return (
     <section className="mx-auto max-w-6xl px-6 py-12">
       <Card className="rounded-2xl border border-gray-200 bg-white shadow-sm">
@@ -83,6 +87,20 @@ export default function AipDetailsSection({ vm, onTabChange, onSearchChange, vie
               </TableBody>
             </Table>
           </div>
+
+          {hasPagination ? (
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-slate-500">Page {page} of {totalPages}</p>
+              <div className="flex gap-2">
+                <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => onPageChange(page - 1)}>
+                  Previous
+                </Button>
+                <Button variant="outline" size="sm" disabled={page >= totalPages} onClick={() => onPageChange(page + 1)}>
+                  Next
+                </Button>
+              </div>
+            </div>
+          ) : null}
 
           <div className="flex justify-end">
             <Button asChild variant="link" className="text-sm font-semibold text-[#0b5188]">

--- a/website/features/citizen/budget-allocation/views/budget-allocation-view.tsx
+++ b/website/features/citizen/budget-allocation/views/budget-allocation-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { DBV2_SECTOR_CODES, getSectorLabel, type DashboardSectorCode } from "@/lib/constants/dashboard";
 import type { BudgetCategoryKey, AipDetailsRowVM } from "@/lib/domain/citizen-budget-allocation";
 import CitizenExplainerCard from "@/features/citizen/components/citizen-explainer-card";
@@ -15,7 +15,9 @@ import { CITIZEN_BUDGET_ALLOCATION_MOCK } from '@/mocks/fixtures/budget-allocati
 import { getRawBudgetAllocationData } from '../data';
 import { normalizeSearchText } from '../utils';
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const DEFAULT_TAB: BudgetCategoryKey = 'general';
+const PAGE_SIZE = 10;
 const CATEGORY_ORDER: BudgetCategoryKey[] = ['general', 'social', 'economic', 'other'];
 const CATEGORY_TO_SECTOR_CODE: Record<BudgetCategoryKey, DashboardSectorCode> = {
   general: '1000',
@@ -23,11 +25,44 @@ const CATEGORY_TO_SECTOR_CODE: Record<BudgetCategoryKey, DashboardSectorCode> = 
   economic: '8000',
   other: '9000',
 };
+const SECTOR_CODE_TO_CATEGORY: Record<DashboardSectorCode, BudgetCategoryKey> = {
+  "1000": "general",
+  "3000": "social",
+  "8000": "economic",
+  "9000": "other",
+};
 const CATEGORY_COLOR_BY_KEY: Record<BudgetCategoryKey, string> = {
   general: '#3B82F6',
   social: '#14B8A6',
   economic: '#22C55E',
   other: '#F59E0B',
+};
+
+type SummaryPayload = {
+  scope?: { scope_name?: string | null };
+  totals?: {
+    by_sector?: Array<{
+      sector_code: DashboardSectorCode;
+      sector_label: string;
+      total: number;
+    }>;
+  };
+  trend?: {
+    years?: number[];
+    series?: Array<{
+      sector_code: DashboardSectorCode;
+      values: number[];
+    }>;
+  };
+};
+
+type ProjectsPayload = {
+  items: Array<{
+    aip_ref_code: string;
+    program_project_description: string;
+    total: number;
+  }>;
+  totalPages: number;
 };
 
 const resolveCategoryKey = (label: string): BudgetCategoryKey | null => {
@@ -44,73 +79,200 @@ export default function CitizenBudgetAllocationView() {
 
   const [activeTab, setActiveTab] = useState<BudgetCategoryKey>(DEFAULT_TAB);
   const [detailsSearch, setDetailsSearch] = useState<string>('');
+  const [selectedYear, setSelectedYear] = useState<number>(vm.filters.selectedYear);
+  const [selectedScopeType, setSelectedScopeType] = useState<"city" | "barangay">(vm.filters.selectedScopeType);
+  const [selectedScopeId, setSelectedScopeId] = useState<string>(vm.filters.selectedScopeId);
+  const [projectPage, setProjectPage] = useState<number>(1);
 
+  const [summaryPayload, setSummaryPayload] = useState<SummaryPayload | null>(null);
+  const [projectItems, setProjectItems] = useState<AipDetailsRowVM[]>([]);
+  const [projectTotalPages, setProjectTotalPages] = useState<number>(1);
+
+  const canFetchLiveData = UUID_PATTERN.test(selectedScopeId);
   const viewAllHref = '/aips';
   const selectedLgu = vm.filters.availableLGUs.find(
-    (option) => option.scopeType === vm.filters.selectedScopeType && option.id === vm.filters.selectedScopeId
+    (option) => option.scopeType === selectedScopeType && option.id === selectedScopeId
   );
   const selectedLguLabel = selectedLgu?.label ?? vm.filters.availableLGUs[0]?.label ?? 'Selected LGU';
 
+  useEffect(() => {
+    if (!canFetchLiveData) return;
+    let cancelled = false;
+
+    const loadSummary = async () => {
+      const params = new URLSearchParams({
+        fiscal_year: String(selectedYear),
+        scope_type: selectedScopeType,
+        scope_id: selectedScopeId,
+      });
+
+      const response = await fetch(`/api/citizen/budget-allocation/summary?${params.toString()}`, { cache: 'no-store' });
+      const payload = (await response.json()) as SummaryPayload;
+      if (!cancelled) {
+        setSummaryPayload(response.ok ? payload : null);
+      }
+    };
+
+    loadSummary().catch(() => {
+      if (!cancelled) setSummaryPayload(null);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [canFetchLiveData, selectedYear, selectedScopeType, selectedScopeId]);
+
+  useEffect(() => {
+    if (!canFetchLiveData) return;
+    let cancelled = false;
+
+    const loadProjects = async () => {
+      const params = new URLSearchParams({
+        fiscal_year: String(selectedYear),
+        scope_type: selectedScopeType,
+        scope_id: selectedScopeId,
+        sector_code: CATEGORY_TO_SECTOR_CODE[activeTab],
+        page: String(projectPage),
+        pageSize: String(PAGE_SIZE),
+      });
+
+      if (detailsSearch.trim()) {
+        params.set('q', detailsSearch.trim());
+      }
+
+      const response = await fetch(`/api/citizen/budget-allocation/projects?${params.toString()}`, { cache: 'no-store' });
+      const payload = (await response.json()) as ProjectsPayload;
+      if (!cancelled) {
+        if (!response.ok) {
+          setProjectItems([]);
+          setProjectTotalPages(1);
+          return;
+        }
+
+        setProjectItems(
+          (payload.items ?? []).map((item) => ({
+            categoryKey: activeTab,
+            aipRefCode: item.aip_ref_code,
+            programDescription: item.program_project_description,
+            totalAmount: typeof item.total === 'number' ? item.total : 0,
+          }))
+        );
+        setProjectTotalPages(Math.max(1, Number(payload.totalPages ?? 1)));
+      }
+    };
+
+    loadProjects().catch(() => {
+      if (!cancelled) {
+        setProjectItems([]);
+        setProjectTotalPages(1);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [canFetchLiveData, selectedYear, selectedScopeType, selectedScopeId, activeTab, projectPage, detailsSearch]);
+
+  const localRows = useMemo(() => {
+    const filteredRows = vm.aipDetails.rows.filter((row: AipDetailsRowVM) => row.categoryKey === activeTab);
+    const detailQuery = normalizeSearchText(detailsSearch).toLowerCase();
+    const searched = detailQuery
+      ? filteredRows.filter(
+          (row: AipDetailsRowVM) =>
+            row.programDescription.toLowerCase().includes(detailQuery) ||
+            row.aipRefCode.toLowerCase().includes(detailQuery)
+        )
+      : filteredRows;
+
+    const from = (projectPage - 1) * PAGE_SIZE;
+    return searched.slice(from, from + PAGE_SIZE);
+  }, [activeTab, detailsSearch, projectPage, vm.aipDetails.rows]);
+
+  const localTotalPages = useMemo(() => {
+    const filteredRows = vm.aipDetails.rows.filter((row: AipDetailsRowVM) => row.categoryKey === activeTab);
+    const detailQuery = normalizeSearchText(detailsSearch).toLowerCase();
+    const searched = detailQuery
+      ? filteredRows.filter(
+          (row: AipDetailsRowVM) =>
+            row.programDescription.toLowerCase().includes(detailQuery) ||
+            row.aipRefCode.toLowerCase().includes(detailQuery)
+        )
+      : filteredRows;
+
+    return Math.max(1, Math.ceil(searched.length / PAGE_SIZE));
+  }, [activeTab, detailsSearch, vm.aipDetails.rows]);
+
   const donutSectors = useMemo(() => {
-    const cardMap = new Map(vm.categoryOverview.cards.map((card) => [card.categoryKey, card]));
+    if (!canFetchLiveData) {
+      const cardMap = new Map(vm.categoryOverview.cards.map((card) => [card.categoryKey, card]));
+      return CATEGORY_ORDER.map((categoryKey) => {
+        const categoryCard = cardMap.get(categoryKey);
+        const sectorCode = CATEGORY_TO_SECTOR_CODE[categoryKey];
+        return {
+          key: categoryKey,
+          label: categoryCard?.label ?? getSectorLabel(sectorCode),
+          amount: categoryCard?.totalAmount ?? 0,
+          color: CATEGORY_COLOR_BY_KEY[categoryKey],
+        };
+      });
+    }
+
+    const bySector = summaryPayload?.totals?.by_sector ?? [];
+    const sectorMap = new Map(bySector.map((sector) => [sector.sector_code, sector]));
     return CATEGORY_ORDER.map((categoryKey) => {
-      const categoryCard = cardMap.get(categoryKey);
       const sectorCode = CATEGORY_TO_SECTOR_CODE[categoryKey];
+      const sector = sectorMap.get(sectorCode);
       return {
         key: categoryKey,
-        label: categoryCard?.label ?? getSectorLabel(sectorCode),
-        amount: categoryCard?.totalAmount ?? 0,
+        label: sector?.sector_label ?? getSectorLabel(sectorCode),
+        amount: typeof sector?.total === 'number' ? sector.total : 0,
         color: CATEGORY_COLOR_BY_KEY[categoryKey],
       };
     });
-  }, [vm.categoryOverview.cards]);
+  }, [canFetchLiveData, summaryPayload, vm.categoryOverview.cards]);
 
   const donutTotal = donutSectors.reduce((total, sector) => total + sector.amount, 0);
 
   const trendData = useMemo(() => {
-    const selectedLguRows = getRawBudgetAllocationData().filter((row) => row.lguName === selectedLguLabel);
-    const rowsByYear = new Map<number, Record<BudgetCategoryKey, number>>();
+    if (!canFetchLiveData) {
+      const selectedLguRows = getRawBudgetAllocationData().filter((row) => row.lguName === selectedLguLabel);
+      const rowsByYear = new Map<number, Record<BudgetCategoryKey, number>>();
+      selectedLguRows.forEach((row) => {
+        const categoryKey = resolveCategoryKey(row.category);
+        if (!categoryKey) return;
+        const yearTotals = rowsByYear.get(row.year) ?? { general: 0, social: 0, economic: 0, other: 0 };
+        yearTotals[categoryKey] += row.budget;
+        rowsByYear.set(row.year, yearTotals);
+      });
 
-    selectedLguRows.forEach((row) => {
-      const categoryKey = resolveCategoryKey(row.category);
-      if (!categoryKey || !DBV2_SECTOR_CODES.includes(CATEGORY_TO_SECTOR_CODE[categoryKey])) return;
+      return Array.from(rowsByYear.entries())
+        .sort((first, second) => first[0] - second[0])
+        .map(([year, totals]) => ({ year, ...totals }));
+    }
 
-      const yearTotals = rowsByYear.get(row.year) ?? {
-        general: 0,
-        social: 0,
-        economic: 0,
-        other: 0,
-      };
-      yearTotals[categoryKey] += row.budget;
-      rowsByYear.set(row.year, yearTotals);
+    const years = Array.isArray(summaryPayload?.trend?.years) ? summaryPayload.trend.years : [];
+    const series = Array.isArray(summaryPayload?.trend?.series) ? summaryPayload.trend.series : [];
+    const seriesMap = new Map(series.map((item) => [item.sector_code, item.values]));
+
+    return years.map((year, yearIndex) => {
+      const point: Record<string, number> = { year };
+      DBV2_SECTOR_CODES.forEach((code) => {
+        const categoryKey = SECTOR_CODE_TO_CATEGORY[code];
+        const values = seriesMap.get(code) ?? [];
+        point[categoryKey] = typeof values[yearIndex] === 'number' ? values[yearIndex] : 0;
+      });
+      return point as { year: number; general: number; social: number; economic: number; other: number };
     });
-
-    return Array.from(rowsByYear.entries())
-      .sort((first, second) => first[0] - second[0])
-      .map(([year, totals]) => ({
-        year,
-        ...totals,
-      }));
-  }, [selectedLguLabel]);
+  }, [canFetchLiveData, selectedLguLabel, summaryPayload]);
 
   const trendSubtitle = trendData.length > 0
     ? `Shows budget trends from ${trendData[0]?.year}-${trendData[trendData.length - 1]?.year}`
     : 'No trend data available for the selected LGU.';
 
-  const filteredRows = vm.aipDetails.rows.filter((row: AipDetailsRowVM) => row.categoryKey === activeTab);
-  const detailQuery = normalizeSearchText(detailsSearch).toLowerCase();
-  const detailRows = detailQuery
-    ? filteredRows.filter(
-        (row: AipDetailsRowVM) =>
-          row.programDescription.toLowerCase().includes(detailQuery) ||
-          row.aipRefCode.toLowerCase().includes(detailQuery)
-      )
-    : filteredRows;
-
   const detailsVm = {
     ...vm.aipDetails,
     activeTab,
-    rows: detailRows,
+    rows: canFetchLiveData ? projectItems : localRows,
     searchText: detailsSearch,
   };
 
@@ -130,19 +292,26 @@ export default function CitizenBudgetAllocationView() {
       <FiltersSection
         filters={{
           ...vm.filters,
-          selectedYear: vm.filters.selectedYear,
-          selectedScopeType: vm.filters.selectedScopeType,
-          selectedScopeId: vm.filters.selectedScopeId,
+          selectedYear,
+          selectedScopeType,
+          selectedScopeId,
         }}
-        onYearChange={() => {}}
-        onLguChange={() => {}}
+        onYearChange={(year) => {
+          setSelectedYear(year);
+          setProjectPage(1);
+        }}
+        onLguChange={(scopeType, scopeId) => {
+          setSelectedScopeType(scopeType);
+          setSelectedScopeId(scopeId);
+          setProjectPage(1);
+        }}
       />
       <OverviewHeader
-        title={`${selectedLguLabel} Budget Allocation Breakdown`}
-        subtitle={`Total budget and allocation by category for FY ${vm.filters.selectedYear}`}
+        title={`${summaryPayload?.scope?.scope_name ?? selectedLguLabel} Budget Allocation Breakdown`}
+        subtitle={`Total budget and allocation by category for FY ${selectedYear}`}
       />
       <ChartsGrid
-        fiscalYear={vm.filters.selectedYear}
+        fiscalYear={selectedYear}
         totalBudget={donutTotal}
         sectors={donutSectors}
         trendSubtitle={trendSubtitle}
@@ -150,9 +319,18 @@ export default function CitizenBudgetAllocationView() {
       />
       <AipDetailsSection
         vm={detailsVm}
-        onTabChange={setActiveTab}
-        onSearchChange={setDetailsSearch}
+        onTabChange={(tab) => {
+          setActiveTab(tab);
+          setProjectPage(1);
+        }}
+        onSearchChange={(value) => {
+          setDetailsSearch(value);
+          setProjectPage(1);
+        }}
         viewAllHref={viewAllHref}
+        page={projectPage}
+        totalPages={canFetchLiveData ? projectTotalPages : localTotalPages}
+        onPageChange={setProjectPage}
       />
     </section>
   );


### PR DESCRIPTION
## Summary
- added `GET /api/citizen/budget-allocation/summary` route handler with force-dynamic behavior, strict query validation, published-only filtering, scope resolution, sector totals, percentage computation, and multi-year trend series output
- added `GET /api/citizen/budget-allocation/projects` route handler with force-dynamic behavior, validation, published-only joins, sector/search filters, deterministic sorting, offset pagination, and count/no-count response support
- wired the citizen budget-allocation view to consume the new APIs for summary + projects while preserving fixture fallback when LGU options are non-UUID mock values
- added page navigation controls to the project details table and connected them to backend pagination

## Details
- summary endpoint enforces `aips.status = 'published'` and supports `scope_type=city|barangay` with `scope_id` UUID and fiscal year required
- projects endpoint enforces same published scope constraints and returns response shape required by UI (`items`, `page`, `pageSize`, `totalRows`, `totalPages`)
- UI now sends `fiscal_year`, `scope_type`, `scope_id`, `sector_code`, `page`, `pageSize`, and optional `q`
- all route errors are mapped to `{ error: { code, message } }` and avoid raw DB error leakage

## Validation
- attempted to run eslint on changed files, but this environment is missing local `eslint` dependency resolution from `website/eslint.config.mjs`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ba31ff50832faed1673261565d64)